### PR TITLE
Use url_for instead of hard-coding.

### DIFF
--- a/wikiware.py
+++ b/wikiware.py
@@ -487,7 +487,7 @@ def get_tag(tag_id):
 @app.route("/logout")
 def logout():
     logout_user()
-    return redirect("/")
+    return redirect(url_for('index'))
 
 
 def create_db():


### PR DESCRIPTION
This PR fixes a bug where logging out would take a user to `/`, without any consideration of the path prefix.