### PR TITLE
Use url_for instead of hardcoding the paths to static files.

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -20,11 +20,11 @@
 <html>
 <head lang="en">
     {% if Options.should_use_local_resources() %}
-    <link href="/static/bootstrap.min.css" rel="stylesheet"/>
+    <link href="{{ url_for('static', filename='bootstrap.min.css') }}" rel="stylesheet"/>
     {% else %}
     <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css" rel="stylesheet"/>
     {% endif %}
-    <link href="/static/wikiware.css" rel="stylesheet"/>
+    <link href="{{ url_for('static', filename='wikiware.css') }} rel="stylesheet"/>
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -84,7 +84,7 @@
 
     {% block endbody %}
     {% if Options.should_use_local_resources() %}
-    <script type="text/javascript" src="/static/jquery-2.1.4.min.js"></script>
+    <script type="text/javascript" src="{{ url_for('static', filename='jquery-2.1.4.min.js') }}></script>
     {% else %}
     <script type="text/javascript" src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
     {% endif %}

--- a/templates/edit.html
+++ b/templates/edit.html
@@ -23,7 +23,7 @@
 {% block head %}
 {{ super() }}
     {% if Options.should_use_local_resources() %}
-    <link href="/static/bootstrap-markdown.min.css" rel="stylesheet"/>
+    <link href="{{ url_for('static', filename='bootstrap-markdown.min.css') }} rel="stylesheet"/>
     {% else %}
     <link href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-markdown/2.8.0/css/bootstrap-markdown.min.css" rel="stylesheet"/>
     {% endif %}
@@ -52,9 +52,9 @@
 {% block endbody %}
     {{ super() }}
     {% if Options.should_use_local_resources() %}
-    <script type="text/javascript" src="/static/bootstrap.min.js"></script>
-    <script type="text/javascript" src="/static/bootstrap-markdown.min.js"></script>
-    <script type="text/javascript" src="/static/markdown.min.js"></script>
+    <script type="text/javascript" src="{{ url_for('static', filename='bootstrap.min.js') }}></script>
+    <script type="text/javascript" src="{{ url_for('static', filename='bootstrap-markdown.min.js') }}></script>
+    <script type="text/javascript" src="{{ url_for('static', filename='markdown.min.js') }}></script>
     {% else %}
     <script type="text/javascript" src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-markdown/2.8.0/js/bootstrap-markdown.min.js"></script>


### PR DESCRIPTION
This PR changes the templates so that they use `url_for` to construct links to static resources, including the path prefix.