### PR TITLE
Table styling

### DIFF
--- a/static/wikiware.css
+++ b/static/wikiware.css
@@ -1,0 +1,10 @@
+
+table {
+    border-collapse: collapse;
+}
+th, td {
+    padding: 3px;
+}
+thead {
+    background-color: #d0d0d0;
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -24,7 +24,7 @@
     {% else %}
     <link href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css" rel="stylesheet"/>
     {% endif %}
-    <link href="{{ url_for('static', filename='wikiware.css') }} rel="stylesheet"/>
+    <link href="{{ url_for('static', filename='wikiware.css') }}" rel="stylesheet"/>
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -84,7 +84,7 @@
 
     {% block endbody %}
     {% if Options.should_use_local_resources() %}
-    <script type="text/javascript" src="{{ url_for('static', filename='jquery-2.1.4.min.js') }}></script>
+    <script type="text/javascript" src="{{ url_for('static', filename='jquery-2.1.4.min.js') }}"></script>
     {% else %}
     <script type="text/javascript" src="https://code.jquery.com/jquery-2.1.4.min.js"></script>
     {% endif %}

--- a/templates/edit.html
+++ b/templates/edit.html
@@ -23,7 +23,7 @@
 {% block head %}
 {{ super() }}
     {% if Options.should_use_local_resources() %}
-    <link href="{{ url_for('static', filename='bootstrap-markdown.min.css') }} rel="stylesheet"/>
+    <link href="{{ url_for('static', filename='bootstrap-markdown.min.css') }}" rel="stylesheet"/>
     {% else %}
     <link href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-markdown/2.8.0/css/bootstrap-markdown.min.css" rel="stylesheet"/>
     {% endif %}
@@ -52,9 +52,9 @@
 {% block endbody %}
     {{ super() }}
     {% if Options.should_use_local_resources() %}
-    <script type="text/javascript" src="{{ url_for('static', filename='bootstrap.min.js') }}></script>
-    <script type="text/javascript" src="{{ url_for('static', filename='bootstrap-markdown.min.js') }}></script>
-    <script type="text/javascript" src="{{ url_for('static', filename='markdown.min.js') }}></script>
+    <script type="text/javascript" src="{{ url_for('static', filename='bootstrap.min.js') }}"></script>
+    <script type="text/javascript" src="{{ url_for('static', filename='bootstrap-markdown.min.js') }}"></script>
+    <script type="text/javascript" src="{{ url_for('static', filename='markdown.min.js') }}"></script>
     {% else %}
     <script type="text/javascript" src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-markdown/2.8.0/js/bootstrap-markdown.min.js"></script>


### PR DESCRIPTION
This PR adds some default CSS styling for html tables. It also fixes an error in #6 that left off `"`'s at the end of some `href` and `src` attributes.