### PR TITLE
Remove prev next

### DIFF
--- a/templates/page.html
+++ b/templates/page.html
@@ -66,24 +66,6 @@
             <a class="btn btn-primary" href="{{ url_for('edit_page', slug=page.slug) }}">Edit</a>
         </div>
     {% endif %}
-    <nav>
-        <ul class="pager">
-            {% if prev_page %}
-            <li class="previous">
-                <a rel="prev"
-                   {% if prev_page %} href="{{ url_for('get_page', slug=prev_page.slug) }}"{% endif %}
-                    ><span aria-hidden="true">&larr;</span> Older</a>
-            </li>
-            {% endif %}
-            {% if next_page %}
-            <li class="next">
-                <a rel="next"
-                   {% if next_page %} href="{{ url_for('get_page', slug=next_page.slug) }}"{% endif %}
-                    >Newer <span aria-hidden="true">&rarr;</span></a>
-            </li>
-            {% endif %}
-        </ul>
-    </nav>
 </div>
 
 {% endblock %}

--- a/templates/page.html
+++ b/templates/page.html
@@ -27,7 +27,7 @@
     </a>
     {% set page_date = page.date.strftime('%Y-%m-%d') %}
     {% set page_l_u_date = page.last_updated_date.strftime('%Y-%m-%d') %}
-    <p class="page-author">Pageed by {{ Options.get_author() }} on {{ page_date }}</p>
+    <p class="page-author">Created by {{ Options.get_author() }} on {{ page_date }}</p>
     {% if page_date != page_l_u_date  %}
     <p class="page-date">Last updated on {{ page_l_u_date  }}</p>
     {% endif %}

--- a/wikiware.py
+++ b/wikiware.py
@@ -374,25 +374,7 @@ def get_page(slug):
         raise Unauthorized()
     user = current_user
 
-    if current_user.is_authenticated:
-        next_page = Page.query\
-            .filter(Page.date > page.date)\
-            .order_by(Page.date.asc()).limit(1).first()
-        prev_page = Page.query\
-            .filter(Page.date < page.date)\
-            .order_by(Page.date.desc()).limit(1).first()
-    else:
-        next_page = Page.query\
-            .filter_by(is_draft=False)\
-            .filter(Page.date > page.date)\
-            .order_by(Page.date.asc()).limit(1).first()
-        prev_page = Page.query\
-            .filter_by(is_draft=False)\
-            .filter(Page.date < page.date)\
-            .order_by(Page.date.desc()).limit(1).first()
-
-    return render_template('page.html', config=Config, page=page, user=user,
-                           next_page=next_page, prev_page=prev_page)
+    return render_template('page.html', config=Config, page=page, user=user)
 
 
 @app.route('/edit/<slug>', methods=['GET', 'POST'])


### PR DESCRIPTION
This PR removes the buttons to the immediately older and newer pages (relative to the current page) from the single-page view. That feature was a hold-over from blogware. 