### PR TITLE
Main page on index

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -21,7 +21,54 @@
 {% block content %}
 
 <div class="container">
+    {% if page %}
+    <a href="{{ url_for('get_page', slug=page.slug) }}">
+        <h1 class="page-title">{{ page.title }}{% if page.is_draft%} <small>(Draft)</small>{% endif %}</h1>
+    </a>
+    {% set page_date = page.date.strftime('%Y-%m-%d') %}
+    {% set page_l_u_date = page.last_updated_date.strftime('%Y-%m-%d') %}
+    <p class="page-author">Created by {{ Options.get_author() }} on {{ page_date }}</p>
+    {% if page_date != page_l_u_date  %}
+    <p class="page-date">Last updated on {{ page_l_u_date  }}</p>
+    {% endif %}
+    <p class="page-tags">Tags:
+        {% for tag in page.tags %}
+        <a href="{{ url_for('get_tag', tag_id=tag.id) }}">{{ tag.name }}</a>
+        {% endfor %}
+    </p>
+    {% if current_user.is_authenticated %}
+        <div>
+            <a class="btn btn-primary" href="{{ url_for('edit_page', slug=page.slug) }}">Edit</a>
+        </div>
+    {% endif %}
+    <hr/>
+
+    <div class="page-content">
+        {{ page.content|gfm }}
+    </div>
+
+    {% if page.notes and current_user.is_authenticated %}
+    <p>&nbsp;</p>
+    <div class="panel panel-default">
+        <div class="panel-heading">
+            <h3 class="panel-title">Notes</h3>
+        </div>
+        <div class="panel-body">
+            {{ page.notes|gfm }}
+        </div>
+    </div>
+    {% else %}
+    <hr/>
+    {% endif %}
+
+    {% if current_user.is_authenticated %}
+        <div>
+            <a class="btn btn-primary" href="{{ url_for('edit_page', slug=page.slug) }}">Edit</a>
+        </div>
+    {% endif %}
+    {% else %}
     <p>Welcome to the {{Options.get_sitename()}} wiki.</p>
+    {% endif %}
 </div>
 
 {% endblock %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -22,50 +22,9 @@
 
 <div class="container">
     {% if page %}
-    <a href="{{ url_for('get_page', slug=page.slug) }}">
-        <h1 class="page-title">{{ page.title }}{% if page.is_draft%} <small>(Draft)</small>{% endif %}</h1>
-    </a>
-    {% set page_date = page.date.strftime('%Y-%m-%d') %}
-    {% set page_l_u_date = page.last_updated_date.strftime('%Y-%m-%d') %}
-    <p class="page-author">Created by {{ Options.get_author() }} on {{ page_date }}</p>
-    {% if page_date != page_l_u_date  %}
-    <p class="page-date">Last updated on {{ page_l_u_date  }}</p>
-    {% endif %}
-    <p class="page-tags">Tags:
-        {% for tag in page.tags %}
-        <a href="{{ url_for('get_tag', tag_id=tag.id) }}">{{ tag.name }}</a>
-        {% endfor %}
-    </p>
-    {% if current_user.is_authenticated %}
-        <div>
-            <a class="btn btn-primary" href="{{ url_for('edit_page', slug=page.slug) }}">Edit</a>
-        </div>
-    {% endif %}
-    <hr/>
-
     <div class="page-content">
         {{ page.content|gfm }}
     </div>
-
-    {% if page.notes and current_user.is_authenticated %}
-    <p>&nbsp;</p>
-    <div class="panel panel-default">
-        <div class="panel-heading">
-            <h3 class="panel-title">Notes</h3>
-        </div>
-        <div class="panel-body">
-            {{ page.notes|gfm }}
-        </div>
-    </div>
-    {% else %}
-    <hr/>
-    {% endif %}
-
-    {% if current_user.is_authenticated %}
-        <div>
-            <a class="btn btn-primary" href="{{ url_for('edit_page', slug=page.slug) }}">Edit</a>
-        </div>
-    {% endif %}
     {% else %}
     <p>Welcome to the {{Options.get_sitename()}} wiki.</p>
     {% endif %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -21,23 +21,7 @@
 {% block content %}
 
 <div class="container">
-    <div class="index-page-list">
-    {% set index = Options.seq().next %}
-    {% set odd_even = Options.cycle(['odd', 'even']).next %}
-    {% for page in pager.items %}
-        <div class="index-page index-page-id-{{page.id}} index-page-index-{{index()}} index-page-{{odd_even()}}">
-            <a href="{{ url_for('get_page', slug=page.slug) }}">
-                <h1>{{ page.title }}{% if page.is_draft%} <small>(Draft)</small>{% endif %}</h1>
-            </a>
-            <p>{{ page.date.strftime('%Y-%m-%d') }} - {{ Options.get_author() }}</p>
-            <blockquote>{{ page.summary if page.summary }}</blockquote>
-            <hr/>
-        </div>
-    {% else %}
-        <p>No pages found</p>
-    {% endfor %}
-    {% include 'page_links.fragment.html' %}
-    </div>
+    <p>Welcome to the {{Options.get_sitename()}} wiki.</p>
 </div>
 
 {% endblock %}

--- a/wikiware.py
+++ b/wikiware.py
@@ -225,6 +225,10 @@ class Page(db.Model):
         return Page.query.filter_by(slug=slug).first()
 
     @classmethod
+    def get_by_title(cls, title):
+        return Page.query.filter_by(title=title).first()
+
+    @classmethod
     def get_unique_slug(cls, title):
         slug = slugify(title)
         if Page.query.filter_by(slug=slug).count() > 0:

--- a/wikiware.py
+++ b/wikiware.py
@@ -303,6 +303,10 @@ class Options(object):
     def should_use_local_resources():
         return Config.LOCAL_RESOURCES
 
+    @staticmethod
+    def get_main_page():
+        return Options.get('main_page')
+
 
 @login_manager.user_loader
 def load_user(user_id):

--- a/wikiware.py
+++ b/wikiware.py
@@ -334,12 +334,8 @@ def index():
         page = Page.get_by_slug(page_name)
     if page and page.is_draft and not current_user.is_authenticated:
         page = None
-    if page:
-        user = current_user
-        return render_template('page.html', config=Config, page=page,
-                               user=user)
-    else:
-        return render_template('index.html')
+    user = current_user
+    return render_template('index.html', config=Config, page=page, user=user)
 
 
 @app.route('/all-pages')

--- a/wikiware.py
+++ b/wikiware.py
@@ -327,14 +327,19 @@ def render_gfm(s):
 
 @app.route("/")
 def index():
-    query = Page.query
-    if not current_user.is_authenticated:
-        query = query.filter_by(is_draft=False)
-    query = query.order_by(Page.date.desc())
-    pager = query.paginate()
-    pages = query
-    return render_template("index.html", pages=pages, pager=pager,
-                           page_links_endpoint='index')
+
+    page_name = Options.get_main_page()
+    page = Page.get_by_title(page_name)
+    if not page:
+        page = Page.get_by_slug(page_name)
+    if page and page.is_draft and not current_user.is_authenticated:
+        page = None
+    if page:
+        user = current_user
+        return render_template('page.html', config=Config, page=page,
+                               user=user)
+    else:
+        return render_template('index.html')
 
 
 @app.route('/all-pages')


### PR DESCRIPTION
This PR adds the ability to specify a main page. The content of the page indicated by the `main_page` option in the db will appear in the index view. This way, the front page is editable.

The `main_page` must be set either to the title or the slug of a page. If `main_page` matches a page's title, that page will be used. If `main_page` doesn't match any page's title but does match a page's slug, that matching page will be used. If `main_page` doesn't match any title or slug, then a generic welcome message will be displayed instead.

If the page indicated is a draft (private), and the viewer of the page is not authenticated, then the generic welcome message will be displayed instead of the main page. In order to allow unauthenticated users to view the main page, the page indicated must not be a draft.
