### PR TITLE
Rename draft to private 1

### DIFF
--- a/wikiware.py
+++ b/wikiware.py
@@ -110,6 +110,9 @@ if __name__ == "__main__":
     parser.add_argument('--set-option', action='store', nargs=2,
                         metavar=('NAME', 'VALUE'))
     parser.add_argument('--clear-option', action='store', metavar='NAME')
+    parser.add_argument('--populate-private', action='store_true',
+                        help='Make sure all is_private fields are populated '
+                             'with the is_draft value.')
 
     args = parser.parse_args()
 
@@ -631,6 +634,11 @@ def run():
         print('Clearing option {}'.format(name))
         print('Old value is "{}"'.format(option.value))
         db.session.delete(option)
+        db.session.commit()
+    elif args.populate_private:
+        pages = Page.query.all()
+        for page in pages:
+            page._is_private = page.is_draft
         db.session.commit()
     else:
         if Config.PATH_PREFIX:

--- a/wikiware.py
+++ b/wikiware.py
@@ -185,7 +185,8 @@ class Page(db.Model):
     notes = db.Column(db.Text)
     date = db.Column(db.DateTime)
     last_updated_date = db.Column(db.DateTime, nullable=False)
-    is_draft = db.Column(db.Boolean, nullable=False, default=False)
+    _is_draft = db.Column(db.Boolean, nullable=False, default=False,
+                          name='is_draft')
     tags = db.relationship('Tag', secondary=tags_table,
                            backref=db.backref('pages', lazy='dynamic'))
 
@@ -247,6 +248,14 @@ class Page(db.Model):
         self._title = value
         if not self.slug and self._title:
             self.slug = self.get_unique_slug(self._title)
+
+    @property
+    def is_draft(self):
+        return self._is_draft
+
+    @is_draft.setter
+    def is_draft(self, value):
+        self._is_draft = value
 
     @property
     def is_private(self):

--- a/wikiware.py
+++ b/wikiware.py
@@ -248,6 +248,14 @@ class Page(db.Model):
         if not self.slug and self._title:
             self.slug = self.get_unique_slug(self._title)
 
+    @property
+    def is_private(self):
+        return self.is_draft
+
+    @is_private.setter
+    def is_private(self, value):
+        self.is_private = value
+
 
 class Tag(db.Model):
     id = db.Column(db.Integer, primary_key=True)

--- a/wikiware.py
+++ b/wikiware.py
@@ -190,6 +190,8 @@ class Page(db.Model):
     last_updated_date = db.Column(db.DateTime, nullable=False)
     _is_draft = db.Column(db.Boolean, nullable=False, default=False,
                           name='is_draft')
+    _is_private = db.Column(db.Boolean, nullable=False, default=False,
+                          name='is_private')
     tags = db.relationship('Tag', secondary=tags_table,
                            backref=db.backref('pages', lazy='dynamic'))
 
@@ -259,6 +261,7 @@ class Page(db.Model):
     @is_draft.setter
     def is_draft(self, value):
         self._is_draft = value
+        self._is_private = value
 
     @property
     def is_private(self):
@@ -267,6 +270,7 @@ class Page(db.Model):
     @is_private.setter
     def is_private(self, value):
         self.is_draft = value
+        self._is_private = value
 
 
 class Tag(db.Model):

--- a/wikiware.py
+++ b/wikiware.py
@@ -254,7 +254,7 @@ class Page(db.Model):
 
     @is_private.setter
     def is_private(self, value):
-        self.is_private = value
+        self.is_draft = value
 
 
 class Tag(db.Model):

--- a/wikiware.py
+++ b/wikiware.py
@@ -340,7 +340,7 @@ def index():
     page = Page.get_by_title(page_name)
     if not page:
         page = Page.get_by_slug(page_name)
-    if page and page.is_draft and not current_user.is_authenticated:
+    if page and page.is_private and not current_user.is_authenticated:
         page = None
     user = current_user
     return render_template('index.html', config=Config, page=page, user=user)
@@ -387,7 +387,7 @@ def get_page(slug):
     page = Page.get_by_slug(slug)
     if not page:
         raise NotFound()
-    if page.is_draft and not current_user.is_authenticated:
+    if page.is_private and not current_user.is_authenticated:
         raise Unauthorized()
     user = current_user
 
@@ -417,7 +417,7 @@ def edit_page(slug):
     page.title = title
     page.content = content
     page.notes = notes
-    page.is_draft = is_draft
+    page.is_private = is_draft
     page.last_updated_date = datetime.now()
 
     current_tags = set(page.tags)


### PR DESCRIPTION
This PR is the first of multiple in a series to rename the `Page.is_draft` field to `Page.is_private`. It adds the new `is_private` column in the db and adds code to keep it in sync with `is_draft`.