### PR TITLE
Rename draft to private 2

### DIFF
--- a/run_tests.py
+++ b/run_tests.py
@@ -37,29 +37,29 @@ class PageTest(unittest.TestCase):
         # then the date is the same as what was passed to the constructor
         self.assertEqual(datetime(2017, 1, 1), page.date)
 
-    def test_init_optional_arg_is_draft(self):
+    def test_init_optional_arg_is_private(self):
         # when a Page is created
         page = wikiware.Page('title', 'content', datetime(2017, 1, 1))
 
-        # then optional argument "is_draft" have its default value of False
-        self.assertFalse(page.is_draft)
+        # then optional argument "is_private" have its default value of False
+        self.assertFalse(page.is_private)
 
-    def test_init_set_is_draft(self):
+    def test_init_set_is_private(self):
         # when a Page is created
         page = wikiware.Page('title', 'content', datetime(2017, 1, 1), True)
 
-        # then the is_draft field is the same as what was passed to the
+        # then the is_private field is the same as what was passed to the
         # constructor
-        self.assertTrue(page.is_draft)
+        self.assertTrue(page.is_private)
 
-    def test_init_set_is_draft_named(self):
+    def test_init_set_is_private_named(self):
         # when a Page is created
         page = wikiware.Page('title', 'content', datetime(2017, 1, 1),
-                             is_draft=True)
+                             is_private=True)
 
-        # then the is_draft field is the same as what was passed to the
+        # then the is_private field is the same as what was passed to the
         # constructor
-        self.assertTrue(page.is_draft)
+        self.assertTrue(page.is_private)
 
     def test_init_optional_arg_notes(self):
 
@@ -74,7 +74,7 @@ class PageTest(unittest.TestCase):
         page = wikiware.Page('title', 'content', datetime(2017, 1, 1), False,
                              'notes')
 
-        # then the is_draft field is the same as what was passed to the
+        # then the is_private field is the same as what was passed to the
         # constructor
         self.assertEqual('notes', page.notes)
 
@@ -83,7 +83,7 @@ class PageTest(unittest.TestCase):
         page = wikiware.Page('title', 'content', datetime(2017, 1, 1), False,
                              notes='notes')
 
-        # then the is_draft field is the same as what was passed to the
+        # then the is_private field is the same as what was passed to the
         # constructor
         self.assertEqual('notes', page.notes)
 

--- a/templates/all_pages.html
+++ b/templates/all_pages.html
@@ -27,7 +27,7 @@
     {% for page in pager.items %}
         <div class="all-pages-page all-pages-page-id-{{page.id}} all-pages-page-index-{{index()}} all-pages-page-{{odd_even()}}">
             <a href="{{ url_for('get_page', slug=page.slug) }}">
-                <h1>{{ page.title }}{% if page.is_draft%} <small>(Draft)</small>{% endif %}</h1>
+                <h1>{{ page.title }}{% if page.is_private%} <small>(Private)</small>{% endif %}</h1>
             </a>
             <p>{{ page.date.strftime('%Y-%m-%d') }} - {{ Options.get_author() }}</p>
             <blockquote>{{ page.summary if page.summary }}</blockquote>

--- a/templates/edit.html
+++ b/templates/edit.html
@@ -40,7 +40,7 @@
             <tr><td>Content</td><td><textarea name="content" rows="24" cols="80" data-provide="markdown">{{ page.content if page.content != None }}</textarea> </td></tr>
             <tr><td>Notes</td><td><textarea name="notes" rows="24" cols="80" data-provide="markdown">{{ page.notes if page.notes != None }}</textarea> </td></tr>
             <tr><td>Date</td><td>{{ page.date if page.date != None }}</td></tr>
-            <tr><td>Is Draft?</td><td><input type="checkbox" name="is_draft" {% if page.is_draft %} checked {% endif %} /></td></tr>
+            <tr><td>Is Private?</td><td><input type="checkbox" name="is_private" {% if page.is_private %} checked {% endif %} /></td></tr>
             <tr><td>Tags</td><td><input type="text" name="tags" value="{%- for tag in page.tags -%}{%- if not loop.first -%},{%-endif-%}{{tag.name}}{%- endfor -%}"></td></tr>
         </table>
         <input class="btn btn-default" type="submit" value="Save"/>

--- a/templates/list_tags.html
+++ b/templates/list_tags.html
@@ -28,7 +28,7 @@
         {% if current_user.is_authenticated %}{%
             set page_count = tag.pages.count()
         %}{% else %}{%
-            set page_count = tag.pages.filter_by(is_draft=False).count()
+            set page_count = tag.pages.filter_by(is_private=False).count()
         %}{% endif %}
         {% if page_count > 0 %}
         <div class="index-tag index-tag-id-{{tag.id}} index-tag-index-{{index()}} index-tag-{{odd_even()}}">

--- a/templates/page.html
+++ b/templates/page.html
@@ -23,7 +23,7 @@
 
 <div class="container">
     <a href="{{ url_for('get_page', slug=page.slug) }}">
-        <h1 class="page-title">{{ page.title }}{% if page.is_draft%} <small>(Draft)</small>{% endif %}</h1>
+        <h1 class="page-title">{{ page.title }}{% if page.is_private%} <small>(Private)</small>{% endif %}</h1>
     </a>
     {% set page_date = page.date.strftime('%Y-%m-%d') %}
     {% set page_l_u_date = page.last_updated_date.strftime('%Y-%m-%d') %}

--- a/templates/tag.html
+++ b/templates/tag.html
@@ -31,7 +31,7 @@
     {% for page in pages %}
         <div class="index-page index-page-id-{{page.id}} index-page-index-{{index()}} index-page-{{odd_even()}}">
             <a href="{{ url_for('get_page', slug=page.slug) }}">
-                <h2>{{ page.title }}{% if page.is_draft%} <small>(Draft)</small>{% endif %}</h2>
+                <h2>{{ page.title }}{% if page.is_private%} <small>(Private)</small>{% endif %}</h2>
             </a>
             <p>{{ page.date.strftime('%Y-%m-%d') }} - {{ Options.get_author() }}</p>
             <hr/>

--- a/wikiware.py
+++ b/wikiware.py
@@ -256,20 +256,19 @@ class Page(db.Model):
 
     @property
     def is_draft(self):
-        return self._is_draft
+        return self.is_private
 
     @is_draft.setter
     def is_draft(self, value):
-        self._is_draft = value
-        self._is_private = value
+        self.is_private = value
 
     @property
     def is_private(self):
-        return self.is_draft
+        return self._is_private
 
     @is_private.setter
     def is_private(self, value):
-        self.is_draft = value
+        self._is_draft = value
         self._is_private = value
 
 

--- a/wikiware.py
+++ b/wikiware.py
@@ -195,12 +195,12 @@ class Page(db.Model):
     tags = db.relationship('Tag', secondary=tags_table,
                            backref=db.backref('pages', lazy='dynamic'))
 
-    def __init__(self, title, content, date, is_draft=False, notes=None):
+    def __init__(self, title, content, date, is_private=False, notes=None):
         self.title = title
         self.content = content
         self.date = date
         self.last_updated_date = date
-        self.is_draft = is_draft
+        self.is_private = is_private
         self.notes = notes
 
     @property
@@ -366,7 +366,7 @@ def index():
 def all_pages():
     query = Page.query
     if not current_user.is_authenticated:
-        query = query.filter_by(is_draft=False)
+        query = query.filter_by(is_private=False)
     query = query.order_by(Page._title.asc())
     pager = query.paginate()
     pages = query
@@ -426,14 +426,14 @@ def edit_page(slug):
         raise BadRequest("The page's title is invalid.")
     content = request.form['content']
     notes = request.form['notes']
-    is_draft = not (not ('is_draft' in request.form and
-                         request.form['is_draft']))
+    is_private = not (not ('is_private' in request.form and
+                           request.form['is_private']))
     tags = request.form['tags']
 
     page.title = title
     page.content = content
     page.notes = notes
-    page.is_private = is_draft
+    page.is_private = is_private
     page.last_updated_date = datetime.now()
 
     current_tags = set(page.tags)
@@ -474,11 +474,11 @@ def create_new():
         raise BadRequest("The page's title is invalid.")
     content = request.form['content']
     notes = request.form['notes']
-    is_draft = not (not ('is_draft' in request.form and
-                         request.form['is_draft']))
+    is_private = not (not ('is_private' in request.form and
+                           request.form['is_private']))
     tags = request.form['tags']
 
-    page = Page(title, content, datetime.now(), is_draft, notes)
+    page = Page(title, content, datetime.now(), is_private, notes)
 
     next_tag_names = set(
         name for name in (
@@ -509,7 +509,7 @@ def get_tag(tag_id):
     tag = Tag.query.get(tag_id)
     query = tag.pages
     if not current_user.is_authenticated:
-        query = query.filter_by(is_draft=False)
+        query = query.filter_by(is_private=False)
     pages = query
     return render_template("tag.html", tag=tag, pages=pages)
 
@@ -642,7 +642,7 @@ def run():
     elif args.populate_private:
         pages = Page.query.all()
         for page in pages:
-            page._is_private = page.is_draft
+            page._is_private = page.is_private
         db.session.commit()
     else:
         if Config.PATH_PREFIX:

--- a/wikiware.py
+++ b/wikiware.py
@@ -253,14 +253,6 @@ class Page(db.Model):
             self.slug = self.get_unique_slug(self._title)
 
     @property
-    def is_draft(self):
-        return self.is_private
-
-    @is_draft.setter
-    def is_draft(self, value):
-        self.is_private = value
-
-    @property
     def is_private(self):
         return self._is_private
 

--- a/wikiware.py
+++ b/wikiware.py
@@ -188,8 +188,6 @@ class Page(db.Model):
     notes = db.Column(db.Text)
     date = db.Column(db.DateTime)
     last_updated_date = db.Column(db.DateTime, nullable=False)
-    _is_draft = db.Column(db.Boolean, nullable=False, default=False,
-                          name='is_draft')
     _is_private = db.Column(db.Boolean, nullable=False, default=False,
                           name='is_private')
     tags = db.relationship('Tag', secondary=tags_table,
@@ -268,7 +266,6 @@ class Page(db.Model):
 
     @is_private.setter
     def is_private(self, value):
-        self._is_draft = value
         self._is_private = value
 
 

--- a/wikiware.py
+++ b/wikiware.py
@@ -188,8 +188,8 @@ class Page(db.Model):
     notes = db.Column(db.Text)
     date = db.Column(db.DateTime)
     last_updated_date = db.Column(db.DateTime, nullable=False)
-    _is_private = db.Column(db.Boolean, nullable=False, default=False,
-                          name='is_private')
+    is_private = db.Column(db.Boolean, nullable=False, default=False,
+                           name='is_private')
     tags = db.relationship('Tag', secondary=tags_table,
                            backref=db.backref('pages', lazy='dynamic'))
 
@@ -251,14 +251,6 @@ class Page(db.Model):
         self._title = value
         if not self.slug and self._title:
             self.slug = self.get_unique_slug(self._title)
-
-    @property
-    def is_private(self):
-        return self._is_private
-
-    @is_private.setter
-    def is_private(self, value):
-        self._is_private = value
 
 
 class Tag(db.Model):


### PR DESCRIPTION
This PR is the second in a series to rename the `Page.is_draft` field to `Page.is_private`. It removes the `is_draft` field completely and moves all functionality to the new `is_private`. 