### PR TITLE
Rename draft to private 3

### DIFF
--- a/wikiware.py
+++ b/wikiware.py
@@ -110,9 +110,6 @@ if __name__ == "__main__":
     parser.add_argument('--set-option', action='store', nargs=2,
                         metavar=('NAME', 'VALUE'))
     parser.add_argument('--clear-option', action='store', metavar='NAME')
-    parser.add_argument('--populate-private', action='store_true',
-                        help='Make sure all is_private fields are populated '
-                             'with the is_draft value.')
 
     args = parser.parse_args()
 
@@ -618,11 +615,6 @@ def run():
         print('Clearing option {}'.format(name))
         print('Old value is "{}"'.format(option.value))
         db.session.delete(option)
-        db.session.commit()
-    elif args.populate_private:
-        pages = Page.query.all()
-        for page in pages:
-            page._is_private = page.is_private
         db.session.commit()
     else:
         if Config.PATH_PREFIX:


### PR DESCRIPTION
This PR is the last in a series to rename the `Page.is_draft` field to `Page.is_private`. It removes the `--populate-private` cli command, and with it the last traces of the `is_draft` field.